### PR TITLE
refactor: remove unused parser directive

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -455,12 +455,6 @@ export interface Subcommand {
      * This is inherited for all subcommands unless overridden.
      */
     optionArgSeparators?: SingleOrArrayOrEmpty<string>;
-
-    /**
-     * Match subcommand names on the shortest unique segment instead of
-     * requiring exact matches
-     */
-    matchShortestUniqueSubcommand?: boolean;
   };
 
   /** Hide this command from any place it may be displayed */


### PR DESCRIPTION
This was an experiment I added while playing around with some ideas. It's not standard, and implementing this feature would likely slow down the library (but it would be an opt-in slow-down)

I don't plan to implement this feature, so I'm removing the property