### PR TITLE
feat: allow matching unique subcommand prefix

### DIFF
--- a/examples/task.ts
+++ b/examples/task.ts
@@ -14,7 +14,7 @@ const spec: Fig.Spec = {
   ],
   requiresSubcommand: true,
   parserDirectives: {
-    matchSubcommandAbbreviation: true,
+    subcommandsMatchUniquePrefix: true,
   },
   subcommands: [
     {

--- a/examples/task.ts
+++ b/examples/task.ts
@@ -13,6 +13,9 @@ const spec: Fig.Spec = {
     Fig.help,
   ],
   requiresSubcommand: true,
+  parserDirectives: {
+    matchSubcommandAbbreviation: true,
+  },
   subcommands: [
     {
       name: "add",

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -16,7 +16,7 @@ interface MinSubcommand<Option extends MinOption> {
     optionArgSeparators?: string | readonly string[];
     flagsArePosixNoncompliant?: boolean;
     optionsMustPrecedeArguments?: boolean;
-    matchSubcommandAbbreviation?: boolean;
+    subcommandsMatchUniquePrefix?: boolean;
   };
 }
 
@@ -244,7 +244,7 @@ export function analyze<
   let separators = ["="];
   let hasFoundArg = false;
   let posixCompliantOptions = true;
-  let matchSubcommandAbbreviation = false;
+  let subcommandsMatchUniquePrefix = false;
   let optionsMustPrecedeArguments = false;
   let hasUsedNonPersistentOption = false;
 
@@ -259,7 +259,7 @@ export function analyze<
       return null;
     }
 
-    if (!matchSubcommandAbbreviation) {
+    if (!subcommandsMatchUniquePrefix) {
       // Only find exact matches.
       return localSubcommands.find((command) =>
         typeof command.name === "string"
@@ -339,8 +339,8 @@ export function analyze<
       );
     }
 
-    if (directives?.matchSubcommandAbbreviation) {
-      matchSubcommandAbbreviation = directives.matchSubcommandAbbreviation;
+    if (directives?.subcommandsMatchUniquePrefix) {
+      subcommandsMatchUniquePrefix = directives.subcommandsMatchUniquePrefix;
     }
 
     if (directives?.optionsMustPrecedeArguments) {

--- a/src/analyze_test.ts
+++ b/src/analyze_test.ts
@@ -395,3 +395,60 @@ Deno.test({
     );
   },
 });
+
+Deno.test({
+  name: "analyze: matchSubcommandAbbreviation",
+  fn() {
+    const spec: Spec = {
+      name: "test",
+      parserDirectives: {
+        matchSubcommandAbbreviation: true,
+      },
+      subcommands: [
+        { name: ["long-name", "name"] },
+        { name: "long-time" },
+      ],
+    };
+    // matches one exactly
+    assertEqualsTokens(
+      analyze(["long-name"], spec),
+      [
+        $subcommand<Subcommand, Option>(
+          0,
+          0,
+          9,
+          "long-name",
+          spec.subcommands![0],
+        ),
+      ],
+    );
+    // should match both, so no unique subcommand, fails subcommand check.
+    // on commands with requiresSubcommand, this will still fail at runtime
+    assertEqualsTokens(
+      analyze(["long-"], spec),
+      [$arg(0, 0, 5, "long-")],
+    );
+    // should match only one
+    assertEqualsTokens(
+      analyze(["long-n"], spec),
+      [$subcommand<Subcommand, Option>(
+        0,
+        0,
+        6,
+        "long-n",
+        spec.subcommands![0],
+      )],
+    );
+    // should match only one
+    assertEqualsTokens(
+      analyze(["n"], spec),
+      [$subcommand<Subcommand, Option>(
+        0,
+        0,
+        1,
+        "n",
+        spec.subcommands![0],
+      )],
+    );
+  },
+});

--- a/src/analyze_test.ts
+++ b/src/analyze_test.ts
@@ -397,12 +397,12 @@ Deno.test({
 });
 
 Deno.test({
-  name: "analyze: matchSubcommandAbbreviation",
+  name: "analyze: subcommandsMatchUniquePrefix",
   fn() {
     const spec: Spec = {
       name: "test",
       parserDirectives: {
-        matchSubcommandAbbreviation: true,
+        subcommandsMatchUniquePrefix: true,
       },
       subcommands: [
         { name: ["long-name", "name"] },

--- a/src/analyze_test.ts
+++ b/src/analyze_test.ts
@@ -407,6 +407,8 @@ Deno.test({
       subcommands: [
         { name: ["long-name", "name"] },
         { name: "long-time" },
+        { name: ["abc-def", "abc-xyz"] },
+        { name: "abc" },
       ],
     };
     // matches one exactly
@@ -419,6 +421,32 @@ Deno.test({
           9,
           "long-name",
           spec.subcommands![0],
+        ),
+      ],
+    );
+    // Matches one exactly, even when it is the prefix of another command
+    assertEqualsTokens(
+      analyze(["abc"], spec),
+      [
+        $subcommand<Subcommand, Option>(
+          0,
+          0,
+          3,
+          "abc",
+          spec.subcommands![3],
+        ),
+      ],
+    );
+    // Match a command when it has two names that share the same prefix
+    assertEqualsTokens(
+      analyze(["abc-"], spec),
+      [
+        $subcommand<Subcommand, Option>(
+          0,
+          0,
+          4,
+          "abc-",
+          spec.subcommands![2],
         ),
       ],
     );

--- a/src/help.ts
+++ b/src/help.ts
@@ -126,7 +126,7 @@ export const usage: Action = ({ path, args: [command], error, help }) => {
   }
 
   if (command === "") {
-    error(`Expected a subcommand, but the value was empty\n\n${
+    error(`Expected a command, but the value was empty\n\n${
       help({
         description: false,
       })

--- a/src/help.ts
+++ b/src/help.ts
@@ -142,7 +142,7 @@ export const usage: Action = ({ path, args: [command], error, help }) => {
     .flatMap((cmd) => cmd.name);
 
   if (subcommands && subcommands.length > 0) {
-    const matchPrefix = getParserDirective(path, "matchSubcommandAbbreviation");
+    const matchPrefix = getParserDirective(path, "subcommandsMatchUniquePrefix");
     if (matchPrefix) {
       const possible = subcommands.filter((name) => name.startsWith(command));
 

--- a/src/help.ts
+++ b/src/help.ts
@@ -126,7 +126,7 @@ export const usage: Action = ({ path, args: [command], error, help }) => {
   }
 
   if (command === "") {
-    error(`Found an empty string, but expected a command\n\n${
+    error(`Expected a subcommand, but the value was empty\n\n${
       help({
         description: false,
       })

--- a/src/help.ts
+++ b/src/help.ts
@@ -142,7 +142,10 @@ export const usage: Action = ({ path, args: [command], error, help }) => {
     .flatMap((cmd) => cmd.name);
 
   if (subcommands && subcommands.length > 0) {
-    const matchPrefix = getParserDirective(path, "subcommandsMatchUniquePrefix");
+    const matchPrefix = getParserDirective(
+      path,
+      "subcommandsMatchUniquePrefix",
+    );
     if (matchPrefix) {
       const possible = subcommands.filter((name) => name.startsWith(command));
 

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -564,7 +564,9 @@ export function assertPrefixMatchCommandsHaveNoArguments(
 
     assert(
       !(subcommand.subcommands && subcommand.args),
-      `The command ${namedArrayToString(...path)} has at least one argument and subcommand, but matches subcommands based on unique prefixes. To fix this, use \`parserDirectives: { subcommandsMatchUniquePrefix: false }\``
+      `The command ${
+        namedArrayToString(...path)
+      } has at least one argument and subcommand, but matches subcommands based on unique prefixes. To fix this, use \`parserDirectives: { subcommandsMatchUniquePrefix: false }\``,
     );
   });
 }

--- a/src/testing.ts
+++ b/src/testing.ts
@@ -10,6 +10,8 @@ import { getMaxArgs, getMinArgs } from "./parse.ts";
 
 const repr = JSON.stringify;
 
+// TODO: one decorators are stable (ts 4.9?), use decorators this file
+
 /**
  * Run a function once for each `args` property in the spec (recursive)
  *
@@ -202,6 +204,7 @@ export function assertLongOptionNamesDoNotStartWithSingleDash(
   spec: Subcommand,
 ): void {
   forEachOptionArray(spec, (options, path) => {
+    // TODO: check if this is correct
     const skip = path
       .map((command) => command.parserDirectives?.flagsArePosixNoncompliant)
       .filter((value) => value !== undefined)
@@ -228,6 +231,7 @@ export function assertOptionNamesStartWithDashes(
   spec: Subcommand,
 ): void {
   forEachOptionArray(spec, (options, path) => {
+    // TODO: check if this is correct
     const skip = path
       .map((command) => command.parserDirectives?.flagsArePosixNoncompliant)
       .filter((value) => value !== undefined)
@@ -283,6 +287,7 @@ export function assertNothingIsNamedDashDash(
 export function assertOptionArgSeparatorsHaveCharacters(
   spec: Subcommand,
 ): void {
+  // FIXME: `subcommands` isn't an array
   forEachSubcommand(spec, (subcommands, path) => {
     for (const [index, subcommand] of makeArray(subcommands).entries()) {
       const separators = makeArray(
@@ -306,6 +311,7 @@ export function assertPlusMinusOptionsTakeOneArg(
   spec: Subcommand,
 ): void {
   forEachOptionArray(spec, (options, path) => {
+    // TODO: check if this is correct
     const skip = path
       .map((command) => command.parserDirectives?.flagsArePosixNoncompliant)
       .filter((value) => value !== undefined)
@@ -345,6 +351,7 @@ export function assertNamesHaveNoExtraWhitespace(
       }
     }
   });
+  // FIXME: `subcommands` isn't an array
   forEachSubcommand(spec, (subcommands, path) => {
     for (const [index, subcommand] of makeArray(subcommands).entries()) {
       for (const name of makeArray(subcommand.name)) {
@@ -385,6 +392,7 @@ export function assertEverythingHasDescription(
       );
     }
   });
+  // FIXME: `subcommands` isn't an array
   forEachSubcommand(spec, (subcommands, path) => {
     for (const [index, subcommand] of makeArray(subcommands).entries()) {
       // deno-fmt-ignore
@@ -420,6 +428,7 @@ export function assertDescriptionLineLengthUnder69(
       }
     }
   });
+  // FIXME: `subcommands` isn't an array
   forEachSubcommand(spec, (subcommands, path) => {
     for (const [index, subcommand] of makeArray(subcommands).entries()) {
       if (subcommand.description) {
@@ -537,6 +546,29 @@ export function assertOptionNameReferencesExist(
   });
 }
 
+/**
+ * Asserts that commands that will match subcommands by prefix do not take arguments
+ */
+export function assertPrefixMatchCommandsHaveNoArguments(
+  spec: Subcommand,
+): void {
+  forEachSubcommand(spec, (subcommand, path) => {
+    // Skip if the final parser directive in the chain is false
+    // TODO: this could probably be a utility function, `isParserDirectiveOn`
+    const skip = path
+      .map((cmd) => cmd.parserDirectives?.subcommandsMatchUniquePrefix)
+      .filter((value) => value !== undefined)
+      .at(-1) === false;
+
+    if (skip) return;
+
+    assert(
+      !(subcommand.subcommands && subcommand.args),
+      `The command ${namedArrayToString(...path)} has at least one argument and subcommand, but matches subcommands based on unique prefixes. To fix this, use \`parserDirectives: { subcommandsMatchUniquePrefix: false }\``
+    );
+  });
+}
+
 export type TestNamingStyle = "sentence" | "function";
 
 /** Options that can be provided to `test` */
@@ -560,6 +592,15 @@ export interface TestOptions {
    * Allows descriptions to have lines over 68 characters long
    */
   allowLongDescriptionLines?: boolean;
+
+  /**
+   * Allow commands to have `parserDirectives.subcommandsMatchUniquePrefix` with args
+   *
+   * This is not allowed by default because it's probably a mistake. It makes
+   * arguments ambiguous, users may not know if their invocation will run a
+   * subcommand or the command.
+   */
+  allowMatchingSubcommandPrefixAndArgs?: boolean;
 
   /**
    * Change the naming style of the tests.
@@ -592,6 +633,7 @@ export function test(
     allowShadowingPersistentOptions = false,
     allowNoDescription = false,
     allowLongDescriptionLines = false,
+    allowMatchingSubcommandPrefixAndArgs = false,
     namingStyle = "sentence",
   } = options;
   return async (t) => {
@@ -757,5 +799,17 @@ export function test(
         assertOptionNameReferencesExist(spec);
       },
     );
+    if (!allowMatchingSubcommandPrefixAndArgs) {
+      await t.step(
+        getName(namingStyle, {
+          "sentence":
+            "Commands with `subcommandsMatchUniquePrefix` don't have arguments and subcommands",
+          "function": "assertPrefixMatchCommandsHaveNoArguments",
+        }),
+        () => {
+          assertPrefixMatchCommandsHaveNoArguments(spec);
+        },
+      );
+    }
   };
 }

--- a/src/testing_test.ts
+++ b/src/testing_test.ts
@@ -914,3 +914,59 @@ Deno.test("testing: assertOptionNameReferencesExist", () => {
     });
   });
 });
+
+Deno.test("testing: assertPrefixMatchCommandsHaveNoArguments", () => {
+  // Valid specs
+  Fig.assertPrefixMatchCommandsHaveNoArguments({ name: "test" });
+  Fig.assertPrefixMatchCommandsHaveNoArguments({
+    name: "test",
+    parserDirectives: {
+      subcommandsMatchUniquePrefix: true,
+    },
+    subcommands: [
+      { name: "something" },
+      { name: "another" },
+    ],
+  });
+  Fig.assertPrefixMatchCommandsHaveNoArguments({
+    name: "test",
+    parserDirectives: {
+      subcommandsMatchUniquePrefix: true,
+    },
+    args: {},
+  });
+  Fig.assertPrefixMatchCommandsHaveNoArguments({
+    name: "test",
+    parserDirectives: {
+      subcommandsMatchUniquePrefix: true,
+    },
+    subcommands: [{
+      name: "test",
+      args: { name: "args" },
+    }],
+  });
+  // Invalid specs
+  assertThrows(() => {
+    Fig.assertPrefixMatchCommandsHaveNoArguments({
+      name: "test",
+      parserDirectives: {
+        subcommandsMatchUniquePrefix: true,
+      },
+      subcommands: [{
+        name: "test",
+        args: { name: "args" },
+        subcommands: [{ name: "test" }]
+      }],
+    });
+  });
+  assertThrows(() => {
+    Fig.assertPrefixMatchCommandsHaveNoArguments({
+      name: "test",
+      parserDirectives: {
+        subcommandsMatchUniquePrefix: true,
+      },
+      args: {name: "test"},
+      subcommands: [{ name: "test" }],
+    });
+  });
+});

--- a/src/testing_test.ts
+++ b/src/testing_test.ts
@@ -955,7 +955,7 @@ Deno.test("testing: assertPrefixMatchCommandsHaveNoArguments", () => {
       subcommands: [{
         name: "test",
         args: { name: "args" },
-        subcommands: [{ name: "test" }]
+        subcommands: [{ name: "test" }],
       }],
     });
   });
@@ -965,7 +965,7 @@ Deno.test("testing: assertPrefixMatchCommandsHaveNoArguments", () => {
       parserDirectives: {
         subcommandsMatchUniquePrefix: true,
       },
-      args: {name: "test"},
+      args: { name: "test" },
       subcommands: [{ name: "test" }],
     });
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -460,7 +460,7 @@ export interface Subcommand {
      * Match subcommand names on the shortest unique segment instead of
      * requiring exact matches
      */
-    matchSubcommandAbbreviation?: boolean;
+    subcommandsMatchUniquePrefix?: boolean;
   };
 
   /** Hide this command from any place it may be displayed */

--- a/src/types.ts
+++ b/src/types.ts
@@ -455,6 +455,12 @@ export interface Subcommand {
      * This is inherited for all subcommands unless overridden.
      */
     optionArgSeparators?: SingleOrArrayOrEmpty<string>;
+
+    /**
+     * Match subcommand names on the shortest unique segment instead of
+     * requiring exact matches
+     */
+    matchSubcommandAbbreviation?: boolean;
   };
 
   /** Hide this command from any place it may be displayed */


### PR DESCRIPTION
Adds a new (non-standard, at the moment) parser directive that will match subcommands by a unique abbreviation. The following subcommands share no common letters, so can be invoked with just `s` or `k`.
```ts
const spec: Spec = {
  name: "test",
  parserDirectives: {
    subcommandsMatchUniquePrefix: true,
  },
  requiresSubcommand: true,
  subcommands: [
    { name: "start" },
    { name: "kill" },
  ],
};
```

Because of `requiresSubcommand: true`, you'd also get the expected runtime behavior if there _was_ a common letter - the command wouldn't match a subcommand, so would fail and show help.

This is also required to accurately model the behavior of commands like tmux.

TODO
- [x] ~~Parser directive naming~~ `subcommandsMatchUniquePrefix`
- [x] ~~Propose upstream~~ upstream is receptive to this change but on the basis of more commands with the same matching logic as tmux
- [x] Better help info for ambiguous commands
- [x] Testing should have a warning for commands with this parser directive _and_ subcommands _and_ args